### PR TITLE
Fix missing prefix in building HTTP query for active tasks

### DIFF
--- a/src/FabianBeiner/Todoist/TodoistTasksTrait.php
+++ b/src/FabianBeiner/Todoist/TodoistTasksTrait.php
@@ -30,7 +30,7 @@ trait TodoistTasksTrait
         $path = 'tasks';
         if (count($options)) {
             $query = http_build_query($options, null, '&', PHP_QUERY_RFC3986);
-            $path  = $path . $query;
+            $path  = $path . '?' . $query;
         }
         /** @var object $result Result of the GET request. */
         $result = $this->get($path);


### PR DESCRIPTION
I found bug in method for getting active tasks with filter parameter (like project_id, section_id etc.)